### PR TITLE
Add ruby client gem for JSON API consumer

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -87,6 +87,8 @@ has a page describing how to emit conformant JSON.
 
 * [hana](https://github.com/tenderlove/hana) implementation of the JSON Patch and JSON pointer spec
 
+* [jsonapi-consumer](https://github.com/jsmestad/jsonapi-consumer) a ruby library for consuming JSONAPI payloads. 
+
 ### Node.js <a href="#relted-tools-node-js" id="relted-tools-node-js" class="headerlink"></a>
 
 * [json-patch](https://www.npmjs.org/package/json-patch) implementation of JSON Patch (rfc6902)

--- a/examples/index.md
+++ b/examples/index.md
@@ -29,6 +29,10 @@ implementations. There is a [custom adapter](https://github.com/daliwali/ember-j
 
 * [jsonapi-ios](https://github.com/joshdholtz/jsonapi-ios) is a library for loading data from a JSON API datasource. Parses JSON API data into models with support for auto-linking of resources and custom model classes.
 
+### Ruby <a href="#client-ruby" id="client-ruby" class="headerlink"></a>
+
+* [jsonapi-consumer](https://github.com/jsmestad/jsonapi-consumer) a ruby library for consuming JSONAPI payloads. 
+
 ## Server <a href="#server" id="server" class="headerlink"></a>
 
 ### PHP <a href="#server-php" id="server-php" class="headerlink"></a>
@@ -86,8 +90,6 @@ has a page describing how to emit conformant JSON.
 * [json-patch](https://github.com/guillec/json-patch) implementation of JSON Patch (rfc6902)
 
 * [hana](https://github.com/tenderlove/hana) implementation of the JSON Patch and JSON pointer spec
-
-* [jsonapi-consumer](https://github.com/jsmestad/jsonapi-consumer) a ruby library for consuming JSONAPI payloads. 
 
 ### Node.js <a href="#relted-tools-node-js" id="relted-tools-node-js" class="headerlink"></a>
 


### PR DESCRIPTION
Add a note about jsonapi-consumer ruby client that consumes JSONAPI format and translates them to ruby objects.